### PR TITLE
automatically build, push and tag new image versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,33 @@
+name: CD to Docker Hub
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ '*' ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker labels & tags metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ github.repository }} # same name/app on dockerhub as on github
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }} # push both tag name and "latest" on new git tag
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
using github action to automatically build, push and tag (both tag name and "latest" on tag push) new versions
docker hub secrets already added to project