### PR TITLE
Classify contractions as warnings and not errors

### DIFF
--- a/vale.ini
+++ b/vale.ini
@@ -11,6 +11,9 @@ Vocab = VSHN
 BasedOnStyles = Microsoft, Openly, Vale
 Openly.Spelling = NO # redundant with Vale.Spelling
 
+# No error for contractions as non-contracted negations are valid for emphasis
+Microsoft.Contractions = warning
+
 # no error while we're building up the VSHN Vocab dictionary
 Vale.Spelling = warning
 


### PR DESCRIPTION
While the Microsoft style guidelines states that you should use contractions to create a friendly and informal tone, it's in my opinion very valid to not contract negations for emphasis.

For example: `Warning: This upgrade cannot be reverted!`

I can see the problem that people will ignore warnings, but I think it's wrong to label it as an error.
