### PR TITLE
Downgrade Microsoft.Dashes to warning

### DIFF
--- a/vale.ini
+++ b/vale.ini
@@ -17,6 +17,9 @@ Microsoft.Contractions = warning
 # No error for quotes formatting
 Microsoft.Quotes = warning
 
+# Don't be pedantic about dashes
+Microsoft.Dashes = warning
+
 # no error while we're building up the VSHN Vocab dictionary
 Vale.Spelling = warning
 


### PR DESCRIPTION
Seems this was changed in a recent version of the Microsoft style, which now breaks existing builds